### PR TITLE
Docs: fix Lab 8 deployment and extracted bot flow

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -16,7 +16,7 @@ Paste your checkpoint evidence below. Add screenshots as image files in the repo
 
 ## Task 2A — Deployed agent
 
-<!-- Paste the WebSocket response showing the agent works through Caddy -->
+<!-- Paste a short nanobot startup log excerpt showing the gateway started inside Docker -->
 
 ## Task 2B — Web client
 

--- a/instructors/lab-plan.md
+++ b/instructors/lab-plan.md
@@ -68,14 +68,14 @@ Students set up nanobot from scratch — same way they would in their own projec
 
 **Part B — Give the agent LMS tools.** Students register provided `mcp/mcp_lms/` in config, write skill prompt. Agent now returns real data. Students compare bare vs equipped responses.
 
-**Part C — Add a chat client.** Flutter client code is provided in `client-web-flutter/`. Students wire it into compose + Caddy (add service, volume, route). Docker builds it (no Flutter SDK needed). Students chat via browser UI.
+**Part C — Add a chat client.** Flutter client code is provided in the external `nanobot-websocket-channel` repo. Students add it as a submodule in Task 2, then wire it into compose + Caddy (add service, volume, route). Docker builds it (no Flutter SDK needed). Students chat via browser UI.
 
 **Autochecker checks:**
 
 | Check | How |
 |---|---|
 | Nanobot service running | `docker compose ps --format json` → nanobot status "running" |
-| WebSocket responds | Send `{"content":"hello"}` via `websocat ws://localhost:42002/ws/chat` → JSON response |
+| WebSocket responds | Send `{"content":"hello"}` via `websocat "ws://localhost:42002/ws/chat?access_key=..."` → JSON response |
 | Agent has LMS tools | Send `{"content":"what labs are available?"}` → response contains real lab names (e.g., "lab-01") |
 | Agent answers quiz question | Send `{"content":"Describe the architecture of the LMS system"}` → mentions "backend", "PostgreSQL" |
 | Flutter client serves | `curl -s -o /dev/null -w '%{http_code}' http://localhost:42002/flutter/` → 200 |
@@ -83,7 +83,7 @@ Students set up nanobot from scratch — same way they would in their own projec
 
 ---
 
-### Task 2 — Give the Agent New Eyes (Observability)
+### Task 3 — Give the Agent New Eyes (Observability)
 
 Students learn to read existing observability data, then give the agent the same ability by writing MCP tools. The backend already has structured logging via OpenTelemetry — students explore it, don't implement it.
 
@@ -102,11 +102,11 @@ Students learn to read existing observability data, then give the agent the same
 | Error-path sequence | Stop postgres, trigger request, parse logs for `db_query` with `level: "error"` |
 | Observability tools work | Send `{"content":"any errors in the last hour?"}` → response NOT "I don't have access to logs" |
 | Agent uses log tools under failure | Same query after stopping postgres → response contains specific error details |
-| REPORT.md sections | `## Task 2A`, `## Task 2B`, `## Task 2C` exist with non-empty content |
+| REPORT.md sections | `## Task 3A`, `## Task 3B`, `## Task 3C` exist with non-empty content |
 
 ---
 
-### Task 3 — Diagnose and Fix a Bug Using the Agent
+### Task 4 — Diagnose and Fix a Bug Using the Agent
 
 Instructor deploys backend with a planted bug. Students use the agent to investigate: "show me recent errors" → "get that trace" → "what service failed?" Students fix the bug, redeploy, verify with agent.
 
@@ -115,11 +115,11 @@ Instructor deploys backend with a planted bug. Students use the agent to investi
 | Check | How |
 |---|---|
 | Bug is fixed | `curl` the broken endpoint → returns 200 (not 500) |
-| Investigation documented | `REPORT.md` has `## Task 3` with conversation transcript, root cause, fix |
+| Investigation documented | `REPORT.md` has `## Task 4` with conversation transcript, root cause, fix |
 
 ---
 
-### Task 4 — Make the Agent Proactive
+### Task 5 — Make the Agent Proactive
 
 **Part A — Multi-step skill.** Students enhance observability skill to chain log → trace queries autonomously. Agent produces coherent summary for "what went wrong?" in a single response.
 
@@ -131,7 +131,7 @@ Instructor deploys backend with a planted bug. Students use the agent to investi
 |---|---|
 | Multi-step skill works | Stop postgres, send `{"content":"what went wrong?"}` → response mentions both log AND trace data |
 | Cron config exists | `nanobot/cron/jobs.json` is valid JSON with `agent_turn` entry and `schedule` field |
-| REPORT.md sections | `## Task 4A`, `## Task 4B` exist with non-empty content |
+| REPORT.md sections | `## Task 5A`, `## Task 5B` exist with non-empty content |
 
 ---
 
@@ -180,7 +180,7 @@ Trace database. When a request flows through multiple services, each step is a s
 
 Main branch = working LMS with no agent. Students create `nanobot/` from scratch.
 
-**Provided:** backend, postgres, caddy, react, qwen-code-api (submodule + compose service), VictoriaLogs/Traces/OTel (in compose), `mcp/mcp_lms/` (provided tools, not wired), Flutter client (external repo, added as submodule in Task 1C).
+**Provided:** backend, postgres, caddy, react, qwen-code-api (submodule + compose service), VictoriaLogs/Traces/OTel (in compose), `mcp/mcp_lms/` (provided tools, not wired), Flutter client (external repo, added as submodule in Task 2).
 
 **Created by students:** `nanobot/` directory (pyproject.toml, config.json, entrypoint.py, Dockerfile), compose services, Caddy routes, skill prompts, structured logging, observability MCP tools, bug fix, cron config, REPORT.md.
 

--- a/lab/setup/setup-full.md
+++ b/lab/setup/setup-full.md
@@ -283,11 +283,11 @@ See [tools](../../wiki/software-types.md#tool).
 1. [Set up the `Qwen Code` API on your VM](../../wiki/qwen-code-api-deployment.md#deploy-the-qwen-code-api-remote).
 2. [Check that the `Qwen Code` API is accessible on your local machine (LOCAL)](../../wiki/qwen-code-api.md#check-that-the-qwen-code-api-is-accessible).
 
-### 1.16. Set up the `Telegram` bot
+### 1.16. Optional: create a `Telegram` bot token
 
 1. [Create a `Telegram` bot](../../wiki/bot.md#create-a-telegram-bot).
-2. [Configure the environment for the bot on your VM (REMOTE)](../../wiki/client-telegram-bot.md#configure-the-environment-remote).
-3. [Install `uv` (REMOTE)](../../wiki/python.md#install-uv).
+2. You do not need to deploy the bot during setup.
+3. If you later do Lab 8 Optional Task 1, follow the task instructions there and the README in the external `nanobot-websocket-channel/client-telegram-bot/` repo.
 
 ### 1.17. Set up the `Autochecker` bot
 

--- a/lab/tasks/optional/task-1.md
+++ b/lab/tasks/optional/task-1.md
@@ -16,8 +16,10 @@ The Telegram Bot API (`api.telegram.org`) is blocked from most Russian servers. 
 
 2. Add a `client-telegram-bot` service to `docker-compose.yml`:
    - Build from `nanobot-websocket-channel/client-telegram-bot/`
-   - Environment: `BOT_TOKEN`, `NANOBOT_WS_URL=ws://nanobot:8765`
+   - Environment: `BOT_TOKEN`, `NANOBOT_WS_URL=ws://nanobot:8765`, `NANOBOT_ACCESS_KEY`
    - `depends_on: nanobot`
+
+   If you want to keep Telegram LMS-specific, users can still provide a per-user LMS key with `/login <api_key>`.
 
 3. Deploy and test. Open Telegram, find your bot, and ask it a question.
 

--- a/lab/tasks/required/task-1.md
+++ b/lab/tasks/required/task-1.md
@@ -45,6 +45,7 @@ Start by reading the [official nanobot repository](https://github.com/HKUDS/nano
    - **Default model:** `coder-model`
 
    This generates `~/.nanobot/config.json` and a workspace at `~/.nanobot/workspace`.
+   In Task 2 you will copy these into a repo-local `nanobot/` project for Docker deployment.
 
 4. Chat with the agent in the terminal on your VM:
 
@@ -147,7 +148,7 @@ The agent works, but it could be smarter about *how* it uses tools. A **skill pr
 
 ### What to do
 
-1. Write a skill prompt at `nanobot/workspace/skills/lms/SKILL.md` (or wherever your workspace is located).
+1. Write a skill prompt in your nanobot workspace, for example at `~/.nanobot/workspace/skills/lms/SKILL.md`.
 
    The skill should teach the agent:
    - Which `mcp_lms_*` tools are available and when to use each one

--- a/lab/tasks/required/task-2.md
+++ b/lab/tasks/required/task-2.md
@@ -17,7 +17,22 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
 
 ### What to do
 
-1. Your `nanobot/` directory needs a few more files for Docker deployment:
+1. Create a repo-local `nanobot/` project from the config and workspace you built in Task 1:
+
+   ```terminal
+   uv init nanobot
+   cd nanobot
+   uv add nanobot-ai --path ../packages/nanobot-ai
+   uv add lms-mcp --path ../mcp
+   cp ~/.nanobot/config.json ./config.json
+   cp -R ~/.nanobot/workspace ./workspace
+   cd ..
+   ```
+
+   From this point on, treat `nanobot/` inside the repository as the deployable copy of your agent project.
+   When you change agent config or skills for the Docker deployment, edit the files in `nanobot/`.
+
+2. Your repo-local `nanobot/` directory needs a few more files for Docker deployment:
 
    - **`entrypoint.py`** — resolves environment variables (LLM API key, host/port, backend URL) into the config at runtime, then launches `nanobot gateway`. This is needed because Docker passes config via env vars, not by editing files.
 
@@ -25,7 +40,7 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
 
    - **`Dockerfile`** — multi-stage build with `uv` (same pattern as `backend/Dockerfile`). Final CMD: `python /app/nanobot/entrypoint.py`.
 
-2. Add a `nanobot` service to `docker-compose.yml`:
+3. Add a `nanobot` service to `docker-compose.yml`:
 
    Use main's nanobot service as reference — it needs:
    - Build context `./nanobot` with `additional_contexts: workspace: .` (so it can access `mcp/` and root `pyproject.toml`)
@@ -33,7 +48,7 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
    - `depends_on: backend`
    - Network: `lms-network`
 
-3. Add a `/ws/chat` route to `caddy/Caddyfile`:
+4. Add a `/ws/chat` route to `caddy/Caddyfile`:
 
    ```
    handle /ws/chat {
@@ -43,16 +58,17 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
 
    Add `nanobot` to caddy's `depends_on` and `NANOBOT_WEBCHAT_CONTAINER_PORT` to its environment.
 
-4. Deploy:
+5. Deploy:
 
    ```terminal
    docker compose --env-file .env.docker.secret up --build -d
    ```
 
-5. Test via WebSocket through Caddy:
+6. Check that the service starts cleanly:
 
    ```terminal
-   echo '{"content":"What labs are available?"}' | websocat ws://localhost:42002/ws/chat
+   docker compose --env-file .env.docker.secret ps
+   docker compose --env-file .env.docker.secret logs nanobot --tail 50
    ```
 
 <!-- STOP -->
@@ -67,8 +83,8 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
 ### Checkpoint
 
 1. `docker compose --env-file .env.docker.secret ps` — nanobot service is running.
-2. WebSocket responds with real LMS data when you ask about labs.
-3. Paste the response into `REPORT.md` under `## Task 2A — Deployed agent`.
+2. `docker compose --env-file .env.docker.secret logs nanobot --tail 50` shows the gateway started without crashing.
+3. Paste a short startup log excerpt into `REPORT.md` under `## Task 2A — Deployed agent`.
 
 ---
 
@@ -134,7 +150,19 @@ Both are in a single repository. The webchat plugin handles:
    }
    ```
 
-6. Redeploy and open `http://localhost:42002/flutter` in a browser. Log in with your `NANOBOT_ACCESS_KEY`. Start by asking the agent:
+6. Redeploy:
+
+   ```terminal
+   docker compose --env-file .env.docker.secret up --build -d
+   ```
+
+7. Test the WebSocket endpoint through Caddy with the deployment access key:
+
+   ```terminal
+   echo '{"content":"What labs are available?"}' | websocat "ws://localhost:42002/ws/chat?access_key=YOUR_NANOBOT_ACCESS_KEY"
+   ```
+
+8. Open `http://localhost:42002/flutter` in a browser. Log in with your `NANOBOT_ACCESS_KEY`. Start by asking the agent:
 
    - `What can you do in this system?`
    - One quiz or LMS/system question of your choice
@@ -150,16 +178,17 @@ Both are in a single repository. The webchat plugin handles:
 
 ### Checkpoint
 
-1. Open `http://localhost:42002/flutter` — you should see a login screen.
-2. Log in with your `NANOBOT_ACCESS_KEY`, ask `What can you do in this system?`, then ask one question from the quiz question bank.
-3. Screenshot the conversation and add it to `REPORT.md` under `## Task 2B — Web client`.
+1. `websocat "ws://localhost:42002/ws/chat?access_key=YOUR_NANOBOT_ACCESS_KEY"` returns a real agent response.
+2. Open `http://localhost:42002/flutter` — you should see a login screen.
+3. Log in with your `NANOBOT_ACCESS_KEY`, ask `What can you do in this system?`, then ask one question from the quiz question bank.
+4. Screenshot the conversation and add it to `REPORT.md` under `## Task 2B — Web client`.
 
 ---
 
 ## Acceptance criteria
 
 - Nanobot runs as a Docker Compose service via `nanobot gateway`.
-- The WebSocket endpoint at `/ws/chat` responds.
+- After the webchat channel is installed, the WebSocket endpoint at `/ws/chat` responds when called with the correct `access_key`.
 - The webchat channel plugin is installed and the Flutter client connects through it.
 - The Flutter web client is accessible at `/flutter` and protected by a student-chosen `NANOBOT_ACCESS_KEY`.
 - `REPORT.md` contains responses from both checkpoints.

--- a/wiki/client-telegram-bot.md
+++ b/wiki/client-telegram-bot.md
@@ -3,137 +3,43 @@
 <h2>Table of contents</h2>
 
 - [About the `Telegram` bot client](#about-the-telegram-bot-client)
-- [Deploy the bot on the VM](#deploy-the-bot-on-the-vm)
-  - [Configure the environment (REMOTE)](#configure-the-environment-remote)
-  - [Start the bot](#start-the-bot)
-    - [Start the bot via `uv run python`](#start-the-bot-via-uv-run-python)
-    - [Start the bot via `uv run poe`](#start-the-bot-via-uv-run-poe)
-    - [Start the bot via `Docker Compose`](#start-the-bot-via-docker-compose)
-  - [Check the bot](#check-the-bot)
-    - [Check the bot via `uv run python`](#check-the-bot-via-uv-run-python)
-    - [Check the bot via `uv run poe`](#check-the-bot-via-uv-run-poe)
-    - [Check the bot in `Telegram`](#check-the-bot-in-telegram)
+- [Where the code lives](#where-the-code-lives)
+- [Environment variables](#environment-variables)
+- [How it fits into Lab 8](#how-it-fits-into-lab-8)
 
 ## About the `Telegram` bot client
 
-The `Telegram` bot client is a standalone [Python](./python.md#what-is-python) service built with `aiogram` that connects the [`Telegram`](./bot.md#about-telegram-bots) messaging interface to the [`Nanobot`](./nanobot.md#about-nanobot) AI agent.
-
-The source code is in the [`client-telegram-bot/`](../client-telegram-bot/) directory.
+The `Telegram` bot client is a standalone [Python](./python.md#what-is-python) service built with `aiogram` that connects the [`Telegram`](./bot.md#about-telegram-bots) messaging interface to the [`Nanobot`](./nanobot.md#about-nanobot) AI agent over the webchat `WebSocket` channel.
 
 Docs:
 
 - [aiogram documentation](https://docs.aiogram.dev/en/latest/)
 
-## Deploy the bot on the VM
+## Where the code lives
 
-1. [Connect to the VM as the user `admin` (LOCAL)](./vm-access.md#connect-to-the-vm-as-the-user-user-local).
-2. [Install `uv` (REMOTE)](./python.md#install-uv).
-3. [Set up the lab repository directory (REMOTE)](./lab.md#set-up-the-lab-repository-directory).
-4. [Configure the environment (REMOTE)](#configure-the-environment-remote).
-5. [Start the bot (REMOTE)](#start-the-bot).
-6. [Check the bot (REMOTE)](#check-the-bot-via-uv-run-poe).
-7. [Check the bot in `Telegram`](#check-the-bot-in-telegram).
+The bot source code is not stored in this lab repository anymore.
+It lives in the standalone `nanobot-websocket-channel` repository:
 
-### Configure the environment (REMOTE)
+<https://github.com/inno-se-toolkit/nanobot-websocket-channel/tree/main/client-telegram-bot>
 
-1. To open [`.env.docker.secret`](./dotenv-docker-secret.md#what-is-envdockersecret) for editing,
+That repo also contains the current Dockerfile, README, and local run instructions for the bot.
 
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
+## Environment variables
 
-   ```terminal
-   nano .env.docker.secret
-   ```
+The current bot expects these variables:
 
-2. [Set the variables in `.env.docker.secret`](./environments.md#set-the-variable-to-value-in-the-env-file-at-file-path):
+- [`BOT_TOKEN`](./dotenv-docker-secret.md#bot_token) — Telegram bot token from `@BotFather`
+- [`NANOBOT_WS_URL`](./dotenv-docker-secret.md#nanobot_ws_url) — `WebSocket` URL for the deployed `Nanobot` channel
+- [`NANOBOT_ACCESS_KEY`](./dotenv-docker-secret.md#nanobot_access_key) — deployment access key required by the webchat channel
 
-   - [`BOT_TOKEN`](./dotenv-docker-secret.md#bot_token)
-   - [`GATEWAY_BASE_URL`](./dotenv-docker-secret.md#gateway_base_url)
-   - [`LMS_API_KEY`](./dotenv-docker-secret.md#lms_api_key)
-   - [`LLM_API_KEY`](./dotenv-docker-secret.md#llm_api_key)
-   - [`LLM_API_BASE_URL`](./dotenv-docker-secret.md#llm_api_base_url)
-   - [`LLM_API_MODEL`](./dotenv-docker-secret.md#llm_api_model)
+If you want the Telegram client to remain LMS-specific, users can still provide a per-user LMS key with `/login <api_key>`.
 
-3. Save and close the file.
+## How it fits into Lab 8
 
-### Start the bot
+In Lab 8 this bot is optional.
+The required path uses the Flutter web client, while the Telegram bot demonstrates that the same agent can serve multiple frontends.
 
-<!-- no toc -->
-- Method 1: [Start the bot via `uv run python`](#start-the-bot-via-uv-run-python)
-- Method 2: [Start the bot via `uv run poe`](#start-the-bot-via-uv-run-poe)
-- Method 3: [Start the bot via `Docker Compose`](#start-the-bot-via-docker-compose)
+For the lab workflow, follow [Optional Task 1](../lab/tasks/optional/task-1.md).
 
-#### Start the bot via `uv run python`
-
-1. To start the bot,
-
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
-
-   ```terminal
-   uv run --env-file .env.docker.secret python bot/bot.py
-   ```
-
-   See [`.env.docker.secret`](./dotenv-docker-secret.md).
-
-#### Start the bot via `uv run poe`
-
-1. To start the bot,
-
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
-
-   ```terminal
-   uv run poe bot
-   ```
-
-   This loads the environment variables from [`.env.docker.secret`](./dotenv-docker-secret.md) automatically.
-
-#### Start the bot via `Docker Compose`
-
-1. To start the bot,
-
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
-
-   ```terminal
-   docker compose up --env-file .env.docker.secret bot --build -d
-   ```
-
-### Check the bot
-
-- Method 1: [Check the bot via `uv run python`](#check-the-bot-via-uv-run-python)
-- Method 2: [Check the bot via `uv run poe`](#check-the-bot-via-uv-run-poe)
-- Method 3: [Check the bot in `Telegram`](#check-the-bot-in-telegram)
-
-#### Check the bot via `uv run python`
-
-1. To check that the bot is working,
-
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
-
-   ```terminal
-   uv run --env-file .env.docker.secret python bot/bot.py --test "/health"
-   ```
-
-   You should see a response from the bot.
-
-#### Check the bot via `uv run poe`
-
-1. To check that the bot is working,
-
-   [run in the `VS Code Terminal`](./vs-code.md#run-a-command-in-the-vs-code-terminal):
-
-   ```terminal
-   uv run poe bot-test "/health"
-   ```
-
-   This loads the environment variables from [`.env.docker.secret`](./dotenv-docker-secret.md) automatically.
-
-   You should see a response from the bot.
-
-#### Check the bot in `Telegram`
-
-1. Open `Telegram`.
-
-2. Find your bot by [your bot username](./bot.md#your-bot-username).
-
-3. Send `/health`.
-
-   You should see a response from your bot.
+> [!NOTE]
+> The Telegram Bot API is blocked from many Russian servers. The bot may need to run locally or on a non-Russian host even though it talks to `Nanobot` over the local Docker network.

--- a/wiki/dotenv-docker-secret.md
+++ b/wiki/dotenv-docker-secret.md
@@ -293,9 +293,7 @@ Default: `<bot-token>`
 
 ## LLM API
 
-<!-- TODO powers clients, not just bot -->
-
-Variables for the [LLM API](./llm-api.md#about-llm-api) that powers the [`Telegram` bot client](./client-telegram-bot.md#about-the-telegram-bot-client).
+Variables for the [LLM API](./llm-api.md#about-llm-api) used by the deployed `Nanobot` agent and related tooling.
 
 ### `LLM_API_KEY`
 

--- a/wiki/nanobot.md
+++ b/wiki/nanobot.md
@@ -48,7 +48,7 @@ It authenticates to the LMS with the deployment's own `NANOBOT_LMS_API_KEY` / `L
 Both the [`Telegram` bot client](./client-telegram-bot.md#about-the-telegram-bot-client) and the `Flutter` web app connect to the same `Nanobot` instance over the [webchat channel](#webchat-channel).
 
 - The [`Telegram` bot client](./client-telegram-bot.md#about-the-telegram-bot-client) forwards free-text messages to `Nanobot` via [`WebSocket`](./websocket.md#what-is-websocket).
-  Slash commands (e.g., `/scores`, `/labs`) are handled directly by the bot without involving `Nanobot`.
+  Local session commands such as `/start`, `/help`, `/login`, and `/logout` are handled directly by the bot.
 - The `Flutter` web app connects to the webchat channel directly and authenticates with the deployment access key.
 
 The [`WebSocket` URL](./websocket.md#websocket-url) is configured by [`NANOBOT_WS_URL`](./dotenv-docker-secret.md#nanobot_ws_url) in [`.env.docker.secret`](./dotenv-docker-secret.md#what-is-envdockersecret).


### PR DESCRIPTION
## Summary
- fix the Task 2 deployment flow so students create a repo-local nanobot project before Dockerizing it
- move the WebSocket proof until after the custom channel is installed and require the deployment access key in examples
- align optional Telegram, full setup, wiki, report, and instructor-plan docs with the extracted nanobot-websocket-channel repo

## Validation
- git diff --check
- targeted grep checks for stale env vars, task numbering, and unauthenticated /ws/chat examples