### PR TITLE
Docs: simplify Lab 8 setup intro

### DIFF
--- a/lab/setup/setup-simple.md
+++ b/lab/setup/setup-simple.md
@@ -340,7 +340,7 @@ LLM_API_MODEL=meta-llama/llama-3.3-70b-instruct:free
 > If not, [set one up](../../wiki/coding-agents.md#choose-and-use-a-coding-agent).
 
 > [!TIP]
-> Ask your coding agent first, then ask the TA.
+> When stuck, ask your coding agent first, then ask the TA.
 
 In this lab, you will use the coding agent (Qwen Code) to help implement tasks. The agent is your development partner — but **make sure you understand what it builds**. Each task has checkpoints where you must verify the results manually.
 


### PR DESCRIPTION
## Summary
- keep only the VM/Remote-SSH note at the top of the simple setup guide
- move the autochecker reminder to the credentials step
- move the coding-agent reminder to the coding-agent section
- fix the observability task reference in setup-simple

## Scope
- lab/setup/setup-simple.md only