### PR TITLE
Docs: scaffold Compose and Caddy integration glue

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -30,7 +30,10 @@
     handle /analytics* {
         reverse_proxy http://backend:{$BACKEND_CONTAINER_PORT}
     }
-    # Students add /ws/chat route here during Task 1A.
+    # Task 2A — uncomment once the nanobot service is running behind Caddy.
+    # handle /ws/chat {
+    #     reverse_proxy http://nanobot:{$NANOBOT_WEBCHAT_CONTAINER_PORT}
+    # }
     handle /utils/pgadmin* {
         reverse_proxy http://pgadmin:{$CONST_PGADMIN_CONTAINER_PORT}
     }
@@ -46,7 +49,12 @@
     handle /openapi.json {
         reverse_proxy http://backend:{$BACKEND_CONTAINER_PORT}
     }
-    # Students add /flutter route here during Task 1C.
+    # Task 2B — uncomment once the Flutter build output is mounted at /srv/flutter.
+    # handle_path /flutter* {
+    #     root * /srv/flutter
+    #     try_files {path} /index.html
+    #     file_server
+    # }
     handle {
         root * /srv/react
         try_files {path} /index.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,42 @@ services:
     volumes:
       - client-web-react:/output
 
-  # Students add client-web-flutter and nanobot services here during Task 1.
+  # Task 2A — uncomment and adapt this service after you create repo-local nanobot/.
+  # nanobot:
+  #   build:
+  #     context: ./nanobot
+  #     additional_contexts:
+  #       workspace: .
+  #     args:
+  #       REGISTRY_PREFIX_DOCKER_HUB: ${REGISTRY_PREFIX_DOCKER_HUB:?'REGISTRY_PREFIX_DOCKER_HUB is required'}
+  #   restart: unless-stopped
+  #   networks:
+  #     - lms-network
+  #   environment:
+  #     # Task 1 used VM-shell URLs. In Docker, use service-to-service URLs instead.
+  #     - LLM_API_KEY=${LLM_API_KEY:?'LLM_API_KEY is required'}
+  #     - LLM_API_BASE_URL=http://qwen-code-api:${QWEN_CODE_API_CONTAINER_PORT:?'QWEN_CODE_API_CONTAINER_PORT is required'}/v1
+  #     - LLM_API_MODEL=${LLM_API_MODEL:?'LLM_API_MODEL is required'}
+  #     - NANOBOT_LMS_BACKEND_URL=http://backend:${BACKEND_CONTAINER_PORT:?'BACKEND_CONTAINER_PORT is required'}
+  #     - NANOBOT_LMS_API_KEY=${LMS_API_KEY:?'LMS_API_KEY is required'}
+  #     - NANOBOT_GATEWAY_CONTAINER_ADDRESS=${NANOBOT_GATEWAY_CONTAINER_ADDRESS:?'NANOBOT_GATEWAY_CONTAINER_ADDRESS is required'}
+  #     - NANOBOT_GATEWAY_CONTAINER_PORT=${NANOBOT_GATEWAY_CONTAINER_PORT:?'NANOBOT_GATEWAY_CONTAINER_PORT is required'}
+  #     - NANOBOT_WEBCHAT_CONTAINER_ADDRESS=${NANOBOT_WEBCHAT_CONTAINER_ADDRESS:?'NANOBOT_WEBCHAT_CONTAINER_ADDRESS is required'}
+  #     - NANOBOT_WEBCHAT_CONTAINER_PORT=${NANOBOT_WEBCHAT_CONTAINER_PORT:?'NANOBOT_WEBCHAT_CONTAINER_PORT is required'}
+  #     - NANOBOT_ACCESS_KEY=${NANOBOT_ACCESS_KEY:?'NANOBOT_ACCESS_KEY is required'}
+  #   depends_on:
+  #     - backend
+  #     - qwen-code-api
+
+  # Task 2B — uncomment after you add nanobot-websocket-channel and want the Flutter build.
+  # client-web-flutter:
+  #   build:
+  #     context: ./nanobot-websocket-channel/client-web-flutter
+  #     args:
+  #       REGISTRY_PREFIX_DOCKER_HUB: ${REGISTRY_PREFIX_DOCKER_HUB:?'REGISTRY_PREFIX_DOCKER_HUB is required'}
+  #       REGISTRY_PREFIX_GHCR: ${REGISTRY_PREFIX_GHCR:?'REGISTRY_PREFIX_GHCR is required'}
+  #   volumes:
+  #     - client-web-flutter:/output
 
   caddy:
     image: ${REGISTRY_PREFIX_DOCKER_HUB}caddy:2.11-alpine
@@ -101,12 +136,18 @@ services:
     depends_on:
       - backend
       - client-web-react
+      # Task 2B — uncomment after you enable the Flutter build service above.
+      # - client-web-flutter
+      # Task 2A — uncomment after you enable the nanobot service above.
+      # - nanobot
       - qwen-code-api
       - victorialogs
       - victoriatraces
     environment:
       - CADDY_CONTAINER_PORT=${CADDY_CONTAINER_PORT:?'CADDY_CONTAINER_PORT is required'}
       - BACKEND_CONTAINER_PORT=${BACKEND_CONTAINER_PORT:?'BACKEND_CONTAINER_PORT is required'}
+      # Task 2A — uncomment when you proxy /ws/chat to nanobot.
+      # - NANOBOT_WEBCHAT_CONTAINER_PORT=${NANOBOT_WEBCHAT_CONTAINER_PORT:?'NANOBOT_WEBCHAT_CONTAINER_PORT is required'}
       - QWEN_CODE_API_CONTAINER_PORT=${QWEN_CODE_API_CONTAINER_PORT:?'QWEN_CODE_API_CONTAINER_PORT is required'}
       - CONST_PGADMIN_CONTAINER_PORT=${CONST_PGADMIN_CONTAINER_PORT:?'CONST_PGADMIN_CONTAINER_PORT is required'}
       - CONST_VICTORIALOGS_CONTAINER_PORT=${CONST_VICTORIALOGS_CONTAINER_PORT:?'CONST_VICTORIALOGS_CONTAINER_PORT is required'}
@@ -116,6 +157,8 @@ services:
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile
       - client-web-react:/srv/react:ro
+      # Task 2B — uncomment when you want Caddy to serve the Flutter build output.
+      # - client-web-flutter:/srv/flutter:ro
 
   qwen-code-api:
     build:
@@ -156,7 +199,21 @@ services:
       retries: 3
       start_period: 10s
 
-  # Students add client-telegram-bot service here during Optional Task 1.
+  # Optional Task 1 — uncomment after you add the Telegram client repo in Task 2.
+  # client-telegram-bot:
+  #   build:
+  #     context: ./nanobot-websocket-channel/client-telegram-bot
+  #     args:
+  #       REGISTRY_PREFIX_DOCKER_HUB: ${REGISTRY_PREFIX_DOCKER_HUB:?'REGISTRY_PREFIX_DOCKER_HUB is required'}
+  #   restart: unless-stopped
+  #   networks:
+  #     - lms-network
+  #   environment:
+  #     - BOT_TOKEN=${BOT_TOKEN:?'BOT_TOKEN is required'}
+  #     - NANOBOT_WS_URL=${NANOBOT_WS_URL:?'NANOBOT_WS_URL is required'}
+  #     - NANOBOT_ACCESS_KEY=${NANOBOT_ACCESS_KEY:?'NANOBOT_ACCESS_KEY is required'}
+  #   depends_on:
+  #     - nanobot
 
   victorialogs:
     image: ${REGISTRY_PREFIX_DOCKER_HUB}victoriametrics/victoria-logs:latest

--- a/lab/tasks/optional/task-1.md
+++ b/lab/tasks/optional/task-1.md
@@ -14,7 +14,7 @@ The Telegram Bot API (`api.telegram.org`) is blocked from most Russian servers. 
 
 1. Get a Telegram bot token from [@BotFather](https://t.me/BotFather).
 
-2. Add a `client-telegram-bot` service to `docker-compose.yml`:
+2. Uncomment the scaffolded `client-telegram-bot` service in `docker-compose.yml`:
    - Build from `nanobot-websocket-channel/client-telegram-bot/`
    - Environment: `BOT_TOKEN`, `NANOBOT_WS_URL=ws://nanobot:8765`, `NANOBOT_ACCESS_KEY`
    - `depends_on: nanobot`

--- a/lab/tasks/required/task-2.md
+++ b/lab/tasks/required/task-2.md
@@ -32,15 +32,14 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
 
    - **`Dockerfile`** — multi-stage build with `uv` (same pattern as `backend/Dockerfile`). Final CMD: `python /app/nanobot/entrypoint.py`.
 
-3. Add a `nanobot` service to `docker-compose.yml`:
+3. Uncomment the scaffolded `nanobot` service block in `docker-compose.yml` and adapt it to your implementation:
 
-   Use main's nanobot service as reference — it needs:
-   - Build context `./nanobot` with `additional_contexts: workspace: .` (so it can access `mcp/` and root `pyproject.toml`)
-   - Environment variables for LLM provider, gateway, webchat, backend URL, and backend API key
-   - `depends_on: backend`
-   - Network: `lms-network`
+   - Keep the build context at `./nanobot` with `additional_contexts: workspace: .` so the image can access `mcp/` and the root project.
+   - Check that the environment variables match what your `entrypoint.py` reads.
+   - Notice that the scaffold uses container-local URLs such as `http://backend:...` and `http://qwen-code-api:...` rather than the VM-shell `localhost` values from Task 1.
+   - Keep it on `lms-network`.
 
-4. Add a `/ws/chat` route to `caddy/Caddyfile`:
+4. Uncomment the scaffolded `/ws/chat` route in `caddy/Caddyfile`, then uncomment the related `nanobot` lines in the `caddy` service inside `docker-compose.yml`:
 
    ```
    handle /ws/chat {
@@ -48,7 +47,10 @@ In Task 1 you ran `nanobot agent` from the VM terminal. For production, nanobot 
    }
    ```
 
-   Add `nanobot` to caddy's `depends_on` and `NANOBOT_WEBCHAT_CONTAINER_PORT` to its environment.
+   You need all three pieces together:
+   - `nanobot` in caddy's `depends_on`
+   - `NANOBOT_WEBCHAT_CONTAINER_PORT` in caddy's environment
+   - the `/ws/chat` route in `Caddyfile`
 
 5. Deploy:
 
@@ -125,15 +127,14 @@ Both are in a single repository. The webchat plugin handles:
    }
    ```
 
-4. Add a `client-web-flutter` service to `docker-compose.yml`:
-   - Build from `nanobot-websocket-channel/client-web-flutter/`
-   - Output to a named volume
-   - Add the volume to the `volumes:` section
+4. Uncomment the scaffolded `client-web-flutter` service in `docker-compose.yml`:
+   - It should build from `nanobot-websocket-channel/client-web-flutter/`
+   - It should write the compiled app into the `client-web-flutter` named volume
 
-5. Update caddy:
+5. Uncomment the scaffolded Flutter-related lines in the `caddy` service and `caddy/Caddyfile`:
    - Mount the Flutter volume at `/srv/flutter:ro`
    - Add `client-web-flutter` to `depends_on`
-   - Add a `/flutter` route:
+   - Enable the `/flutter` route:
 
    ```
    handle_path /flutter* {


### PR DESCRIPTION
Summary:
- add commented nanobot, Flutter, and Telegram service blocks in docker-compose.yml
- add commented /ws/chat and /flutter routes plus related caddy wiring
- update Task 2 and Optional Task 1 to tell students to uncomment and adapt the scaffold instead of reverse-engineering the infrastructure glue
